### PR TITLE
Serve MEDIA_ROOT directory under MEDIA_URL when DEBUG is True

### DIFF
--- a/project_name/urls.py
+++ b/project_name/urls.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.conf.urls import patterns, include, url
+from django.conf.urls.static import static
 from django.contrib import admin
 
 
@@ -8,12 +9,4 @@ admin.autodiscover()
 
 urlpatterns = patterns('',
     url(r'^admin/', include(admin.site.urls)),
-)
-
-
-if settings.DEBUG:
-    urlpatterns += patterns('',
-        url(r'^{0}(?P<path>.*)$'.format(settings.MEDIA_URL.lstrip('/')),
-            'django.views.static.serve', {'document_root': settings.MEDIA_ROOT}
-        ),
-   )
+) + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
The title kind of says it all. `STATIC_ROOT` is served by `contrib.staticfiles` but `MEDIA_ROOT` is not.
