### PR TITLE
Migration Detection

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -232,9 +232,9 @@ def collectstatic():
 
 
 def match_changes(branch, match):
-    changes = run("git diff {0} origin/{0} --stat-name-width=256".format(branch))
+    changes = run("git diff {0} origin/{0} --stat-name-width=9999".format(branch))
     pattern = re.compile(match)
-    return pattern.search(changes)
+    return pattern.search(changes) is not None
 
 
 @task


### PR DESCRIPTION
Change to the `match_changes` to fix a few problems we've seen with detecting when there are migrations (See #7). This uses @daaray's idea to increase the file name width (which was using the default 80 characters). It also moves the regex matching from grep to Python.
