### PR TITLE
vagrant git clone fails

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,24 @@ You should now be able to run the development server::
     python manage.py runserver
 
 
+Setup repository
+------------------------
+
+Before your project can be deployed to a server, the code needs to be
+accessible in a git repository.
+
+1. Add your project code to a git repo, hosted somewhere your server can clone it from.
+
+2. Edit ``fabfile.py`` near the top and insert your repo's URL.  E.g., change this::
+
+    env.repo = u'' # FIXME: Add repo URL
+
+   to this::
+
+    env.repo = u'git@github.com:account/reponame.git'
+
+
+
 Server Provisioning
 ------------------------
 


### PR DESCRIPTION
With the latest master, setting up a vagrant server, it gets to the point where it's trying to clone the git repository and fails.  It appears that it's running as 'poirier' but trying to clone into /home/<projectname>/www/staging, where poirier doesn't have write permission.

I believe it's ssh'ing in as poirier and not sudo'ing to the project user because that would lose the ssh agent forwarding, so not sure how to solve this.  But does it work without vagrant?  What would be different?
