### PR TITLE
Switch to PyLibMC by Default

### DIFF
--- a/project_name/settings/staging.py
+++ b/project_name/settings/staging.py
@@ -18,7 +18,7 @@ INSTALLED_APPS += (
 
 CACHES = {
     'default': {
-        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'BACKEND': 'django.core.cache.backends.memcached.PyLibMCCache',
         'LOCATION': '127.0.0.1:11211',
     }
 }

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,4 +2,4 @@
 gunicorn==0.14.2
 greenlet==0.3.4
 gevent==0.13.6
-python-memcached==1.48
+pylibmc==1.2.3


### PR DESCRIPTION
See #15. Might not be as relevant with #35 removing gevent by default but I've hit a number of issues with python-memcache not exactly playing nice with the gevent monkey patch.
