### PR TITLE
Secrets aren't loaded for manage_run

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -131,7 +131,7 @@ def update_requirements():
 def manage_run(command):
     """Run a Django management command on the remote server."""
     require('environment')
-    manage_base = u"%(virtualenv_root)s/bin/django-admin.py " % env
+    manage_base = u"source %(virtualenv_root)s/bin/activate && %(virtualenv_root)s/bin/django-admin.py " % env
     if '--settings' not in command:
         command = u"%s --settings=%s" % (command, env.settings)
     project_run(u'%s %s' % (manage_base, command))


### PR DESCRIPTION
Load the virtualenv so the secrets are available in the environment when running manage commands.
