### PR TITLE
Make code root group writable

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -193,6 +193,7 @@ def deploy(branch=None):
         path_file = os.path.join(env.virtualenv_root, 'lib', 'python2.7', 'site-packages', 'project.pth')
         files.append(path_file, env.code_root, use_sudo=True)
         sudo('chown %s:%s %s' % (env.project_user, env.project_user, path_file))
+        sudo('chmod 775 %(code_root)s' % env)
     sudo('chown %(project_user)s:admin -R %(code_root)s' % env)
     if requirements:
         update_requirements()


### PR DESCRIPTION
The code root needs to be editable by the group (admin) so directory changes (like removing files) work when running a git pull. Otherwise you get weird errors about unable to unlink files, etc. on a git pull.
