### PR TITLE
less v1.4 doesn't work with 12.04 version of nodejs

### DIFF
--- a/conf/local/project/app.sls
+++ b/conf/local/project/app.sls
@@ -123,7 +123,7 @@ npm:
 
 less:
   cmd.run:
-    - name: npm install less -g
+    - name: npm install less@1.3.3 -g
     - user: root
     - unless: which lessc
     - require:


### PR DESCRIPTION
I had to pin less to 1.3 to work with the version of Node in precise. We could probably use a PPA for a newer version of Node, but this seemed easier for the time being since I don't know if everything is compatible with Node v0.10.
