### PR TITLE
Reload supervisor config when confs are updated

### DIFF
--- a/conf/local/project/app.sls
+++ b/conf/local/project/app.sls
@@ -89,6 +89,8 @@ group_conf:
     - require:
       - pkg: supervisor
       - file: log_dir
+    - watch_in:
+      - cmd: supervisor_update
 
 gunicorn_conf:
   file.managed:
@@ -107,6 +109,8 @@ gunicorn_conf:
     - require:
       - pkg: supervisor
       - file: log_dir
+    - watch_in:
+      - cmd: supervisor_update
 
 gunicorn_process:
   supervisord:

--- a/conf/local/project/worker.sls
+++ b/conf/local/project/worker.sls
@@ -23,6 +23,8 @@ celery_conf:
     - require:
       - pkg: supervisor
       - file: log_dir
+    - watch_in:
+      - cmd: supervisor_update
 
 celery_process:
   supervisord:


### PR DESCRIPTION
This was the only way I could reliably get the supervisor configuration to reload automatically. I tried adding watch statements to the supervisor service directly, but it didn't update the configurations. So I ended up adding a separate `supervisor_update` command that can be triggered via `watch_in` on the appropriate configurations.
