### PR TITLE
Salt Bootstrap

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -62,7 +62,7 @@ def provision(common='master'):
     if not installed:
         bootstrap_file = os.path.join(CONF_ROOT, 'bootstrap-salt.sh')
         put(bootstrap_file, '/tmp/bootstrap-salt.sh')
-        sudo('sh /tmp/bootstrap-salt.sh daily')
+        sudo('sh /tmp/bootstrap-salt.sh stable')
     # Rsync local states and pillars
     minion_file = os.path.join(CONF_ROOT, 'minion.conf')
     files.upload_template(minion_file, '/etc/salt/minion', use_sudo=True, context=env)


### PR DESCRIPTION
Currently the initial provision uses the daily Salt build. @copelco was noting some problems with the latest stable build. @daaray and I have both run into bugs using the daily which is not very stable. Depending on the day you provision you can run into various bugs which is difficult to reproduce and debug. You can always update the daily build to the latest day via apt. Do we want to stick with daily or go back to stable?
