### PR TITLE
BREACH related GZIP changes

### DIFF
--- a/conf/local/project/nginx.conf
+++ b/conf/local/project/nginx.conf
@@ -35,6 +35,7 @@ server {
     }
 
     location /static {
+        gzip on;
         alias {{ public_root }}/static;
         expires max;
     }
@@ -45,6 +46,7 @@ server {
     }
 
     location / {
+        gzip off;
         {% if auth_file %}
         auth_basic "Restricted";
         auth_basic_user_file {{ auth_file }};


### PR DESCRIPTION
Enable gzip compression for the static files but ensure that compression is disabled for the Django related content (BREACH).
