### PR TITLE
Fixes #58 auth_file variable undefined.

### DIFF
--- a/conf/local/project/nginx.conf
+++ b/conf/local/project/nginx.conf
@@ -45,7 +45,7 @@ server {
     }
 
     location / {
-        {% if auth_file %}
+        {% if 'http_auth' in pillar %}
         auth_basic "Restricted";
         auth_basic_user_file {{ auth_file }};
         {% endif %}


### PR DESCRIPTION
Instead of checking if this variable exists, which doesn't
if http_auth has not been enabled, we can check if http_auth
has been defined.
