### PR TITLE
Only create venv after python-headers installed

### DIFF
--- a/conf/local/project/app.sls
+++ b/conf/local/project/app.sls
@@ -36,6 +36,7 @@ venv:
     - require:
       - pip: virtualenv
       - file: root_dir
+      - pkg: python-headers
 
 venv_dir:
   file.directory:


### PR DESCRIPTION
Specifically for Pillow. If it doesn't find certain headers, then it doesn't enable those features. Currently, the virtualenv gets created and the requirements installed before the python-headers get installed.
