### PR TITLE
Use bash for the project_user account

### DIFF
--- a/conf/local/project/user.sls
+++ b/conf/local/project/user.sls
@@ -1,5 +1,6 @@
 project_user:
   user.present:
     - name: {{ pillar['project_name'] }}
+    - shell: /bin/bash
     - remove_groups: False
     - groups: [www-data]


### PR DESCRIPTION
In a perfect world, you'd never have to actually log in to the server and sudo to the project_user account. But when you do, it's nice to have bash, rather than sh.
