### PR TITLE
Don't specify nodejs version

### DIFF
--- a/conf/local/project/app.sls
+++ b/conf/local/project/app.sls
@@ -118,7 +118,6 @@ node_ppa:
 
 nodejs:
   pkg.installed:
-    - version: 0.10.13-1chl1~precise1
     - require:
       - pkgrepo: node_ppa
     - refresh: True


### PR DESCRIPTION
Anytime the nodejs PPA gets updated, the salt state will fail because it can no longer find the specific version that we've requested. This is (in my mind) a failing of the apt packaging system in that you can't specify the version of the package that you want, only that you want the latest version.

This PR removes the 'version' specifier for nodejs.
