### PR TITLE
[fixes #70] Enabling basic auth fix.

### DIFF
--- a/conf/salt/project/_vars.sls
+++ b/conf/salt/project/_vars.sls
@@ -12,6 +12,7 @@
   {{ build_path(root_dir, name) }}
 {%- endmacro %}
 
+{% set auth_file = path_from_root(".htpasswd") %}
 {% set current_ip = grains['ip_interfaces'].get(salt['pillar.get']('primary_iface', 'eth0'), [])[0] %}
 {% set log_dir = path_from_root('log') %}
 {% set public_dir = path_from_root('public') %}

--- a/conf/salt/project/web/balancer.sls
+++ b/conf/salt/project/web/balancer.sls
@@ -1,4 +1,5 @@
 {% import 'project/_vars.sls' as vars with context %}
+{% set auth_file=vars.auth_file %}
 
 include:
   - nginx


### PR DESCRIPTION
{{ auht_file }} was not defined in the balancer.sls state.
