### PR TITLE
Construct ssh_dir variable using concatenation syntax

### DIFF
--- a/conf/salt/project/_vars.sls
+++ b/conf/salt/project/_vars.sls
@@ -16,7 +16,7 @@
 {% set current_ip = grains['ip_interfaces'].get(salt['pillar.get']('primary_iface', 'eth0'), [])[0] %}
 {% set log_dir = path_from_root('log') %}
 {% set public_dir = path_from_root('public') %}
-{% set ssh_dir = "/home/{{ pillar['project_name'] }}/.ssh/" %}
+{% set ssh_dir = "/home/" + pillar['project_name'] + "/.ssh/" %}
 {% set ssl_dir = path_from_root('ssl') %}
 {% set source_dir = path_from_root('source') %}
 {% set venv_dir = path_from_root('env') %}


### PR DESCRIPTION
I'm not sure why, but I don't think the `{{ pillar[] }}` syntax works within _vars.sls. I fixed it with +. Otherwise it created a directory structure like this and put .ssh/ into a folder named `{{ pillar['project_name'] }}`:

```
/home# ls -la
total 24
drwxr-xr-x  6 root     root     4096 Jan 25 20:09 .
drwxr-xr-x 24 root     root     4096 Jan 25 20:11 ..
drwxr-xr-x  4 copelco  copelco  4096 Jan 25 20:17 copelco
drwxr-xr-x  3 myproj myproj 4096 Jan 25 20:07 myproj
drwx------  3 myproj myproj 4096 Jan 25 20:09 {{ pillar['project_name'] }}
drwxr-xr-x  4 ubuntu   ubuntu   4096 Jan 25 20:01 ubuntu
```
