### PR TITLE
Set CELERY_EAGER_PROPAGATES_EXCEPTIONS

### DIFF
--- a/project_name/settings/dev.py
+++ b/project_name/settings/dev.py
@@ -22,11 +22,6 @@ COMPRESS_ENABLED = False
 
 # Special test settings
 if 'test' in sys.argv:
-    CELERY_ALWAYS_EAGER = True
-    CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
-
-    COMPRESS_ENABLED = False
-
     COMPRESS_PRECOMPILERS = ()
 
     PASSWORD_HASHERS = (


### PR DESCRIPTION
Celery eats exceptions when CELERY_ALWAYS_EAGER is True. This allows those exceptions to be seen.
