### PR TITLE
RabbitMQ vhost 'user' option has been deprecated in favor of 'owner'

### DIFF
--- a/conf/salt/project/queue.sls
+++ b/conf/salt/project/queue.sls
@@ -15,7 +15,7 @@ broker-user:
 broker-vhost:
   rabbitmq_vhost.present:
     - name: {{ pillar['project_name'] }}_{{ pillar['environment'] }}
-    - user: {{ pillar['project_name'] }}_{{ pillar['environment'] }}
+    - owner: {{ pillar['project_name'] }}_{{ pillar['environment'] }}
     - require:
       - rabbitmq_user: broker-user
 


### PR DESCRIPTION
Apparently the 'user' option was deprecated in 0.17.0, it is best to start using 'owner' instead.

https://github.com/saltstack/salt/blob/develop/salt/states/rabbitmq_vhost.py#L51, 
