### PR TITLE
Postgres authentication error

### DIFF
--- a/conf/salt/project/db/init.sls
+++ b/conf/salt/project/db/init.sls
@@ -26,7 +26,6 @@ database-{{ pillar['project_name'] }}:
     - lc_ctype: en_US.UTF-8
     - require:
       - postgres_user: user-{{ pillar['project_name'] }}
-      - file: /var/lib/postgresql/configure_utf-8.sh
       - file: hba_conf
       - file: postgresql_conf
 
@@ -46,6 +45,7 @@ hba_conf:
 {% endfor %}
     - require:
       - pkg: postgresql
+      - cmd: /var/lib/postgresql/configure_utf-8.sh
     - watch_in:
       - service: postgresql
 
@@ -59,6 +59,7 @@ postgresql_conf:
     - template: jinja
     - require:
       - pkg: postgresql
+      - cmd: /var/lib/postgresql/configure_utf-8.sh
     - watch_in:
       - service: postgresql
 


### PR DESCRIPTION
Working on the vagrant setup and I'm down to one final error that I haven't yet figured out.

```
[33.33.33.10] out: ----------
[33.33.33.10] out:           ID: syncdb
[33.33.33.10] out:     Function: cmd.run
[33.33.33.10] out:         Name: /var/www/testdpt/manage.sh syncdb --noinput
[33.33.33.10] out:       Result: False
[33.33.33.10] out:      Comment: Command "/var/www/testdpt/manage.sh syncdb --noinput" run
[33.33.33.10] out:      Changes:   
[33.33.33.10] out:               ----------
[33.33.33.10] out:               pid:
[33.33.33.10] out:                   6982
[33.33.33.10] out:               retcode:
[33.33.33.10] out:                   1
[33.33.33.10] out:               stderr:
[33.33.33.10] out:                   Traceback (most recent call last):
[33.33.33.10] out:                     File "/var/www/testdpt/source/manage.py", line 10, in <module>
[33.33.33.10] out:                       execute_from_command_line(sys.argv)
[33.33.33.10] out:                     File "/var/www/testdpt/env/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 399, in execute_from_command_line
[33.33.33.10] out:                       utility.execute()
[33.33.33.10] out:                     File "/var/www/testdpt/env/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 392, in execute
[33.33.33.10] out:                       self.fetch_command(subcommand).run_from_argv(self.argv)
[33.33.33.10] out:                     File "/var/www/testdpt/env/local/lib/python2.7/site-packages/django/core/management/base.py", line 242, in run_from_argv
[33.33.33.10] out:                       self.execute(*args, **options.__dict__)
[33.33.33.10] out:                     File "/var/www/testdpt/env/local/lib/python2.7/site-packages/django/core/management/base.py", line 285, in execute
[33.33.33.10] out:                       output = self.handle(*args, **options)
[33.33.33.10] out:                     File "/var/www/testdpt/env/local/lib/python2.7/site-packages/django/core/management/base.py", line 415, in handle
[33.33.33.10] out:                       return self.handle_noargs(**options)
[33.33.33.10] out:                     File "/var/www/testdpt/env/local/lib/python2.7/site-packages/south/management/commands/syncdb.py", line 92, in handle_noargs
[33.33.33.10] out:                       syncdb.Command().execute(**options)
[33.33.33.10] out:                     File "/var/www/testdpt/env/local/lib/python2.7/site-packages/django/core/management/base.py", line 285, in execute
[33.33.33.10] out:                       output = self.handle(*args, **options)
[33.33.33.10] out:                     File "/var/www/testdpt/env/local/lib/python2.7/site-packages/django/core/management/base.py", line 415, in handle
[33.33.33.10] out:                       return self.handle_noargs(**options)
[33.33.33.10] out:                     File "/var/www/testdpt/env/local/lib/python2.7/site-packages/django/core/management/commands/syncdb.py", line 57, in handle_noargs
[33.33.33.10] out:                       cursor = connection.cursor()
[33.33.33.10] out:                     File "/var/www/testdpt/env/local/lib/python2.7/site-packages/django/db/backends/__init__.py", line 157, in cursor
[33.33.33.10] out:                       cursor = self.make_debug_cursor(self._cursor())
[33.33.33.10] out:                     File "/var/www/testdpt/env/local/lib/python2.7/site-packages/django/db/backends/__init__.py", line 129, in _cursor
[33.33.33.10] out:                       self.ensure_connection()
[33.33.33.10] out:                     File "/var/www/testdpt/env/local/lib/python2.7/site-packages/django/db/backends/__init__.py", line 124, in ensure_connection
[33.33.33.10] out:                       self.connect()
[33.33.33.10] out:                     File "/var/www/testdpt/env/local/lib/python2.7/site-packages/django/db/utils.py", line 99, in __exit__
[33.33.33.10] out:                       six.reraise(dj_exc_type, dj_exc_value, traceback)
[33.33.33.10] out:                     File "/var/www/testdpt/env/local/lib/python2.7/site-packages/django/db/backends/__init__.py", line 124, in ensure_connection
[33.33.33.10] out:                       self.connect()
[33.33.33.10] out:                     File "/var/www/testdpt/env/local/lib/python2.7/site-packages/django/db/backends/__init__.py", line 112, in connect
[33.33.33.10] out:                       self.connection = self.get_new_connection(conn_params)
[33.33.33.10] out:                     File "/var/www/testdpt/env/local/lib/python2.7/site-packages/django/db/backends/postgresql_psycopg2/base.py", line 116, in get_new_connection
[33.33.33.10] out:                       return Database.connect(**conn_params)
[33.33.33.10] out:                     File "/var/www/testdpt/env/local/lib/python2.7/site-packages/psycopg2/__init__.py", line 164, in connect
[33.33.33.10] out:                       conn = _connect(dsn, connection_factory=connection_factory, async=async)
[33.33.33.10] out:                   django.db.utils.OperationalError: FATAL:  Peer authentication failed for user "testdpt_local"
[33.33.33.10] out:               stdout:
[33.33.33.10] out:                   Syncing...
```

Again, it only happens on the first highstate. On the second highstate it (and the entire highstate) succeeds.
