### PR TITLE
Fix UFW States 

### DIFF
--- a/conf/salt/project/cache.sls
+++ b/conf/salt/project/cache.sls
@@ -4,9 +4,9 @@ include:
   - memcached
   - ufw
 
-cache_firewall:
 {% for host, ifaces in salt['mine.get']('roles:web|worker', 'network.interfaces', expr_form='grain_pcre').items() %}
 {% set host_addr = vars.get_primary_ip(ifaces) %}
+cache_allow-{{ host_addr }}:
   ufw.allow:
     - name: '11211'
     - enabled: true

--- a/conf/salt/project/db/init.sls
+++ b/conf/salt/project/db/init.sls
@@ -63,9 +63,9 @@ postgresql_conf:
     - watch_in:
       - service: postgresql
 
-db_firewall:
 {% for host, ifaces in salt['mine.get']('roles:web|worker', 'network.interfaces', expr_form='grain_pcre').items() %}
 {% set host_addr = vars.get_primary_ip(ifaces) %}
+db_allow-{{ host_addr }}:
   ufw.allow:
     - name: '5432'
     - enabled: true

--- a/conf/salt/project/queue.sls
+++ b/conf/salt/project/queue.sls
@@ -19,9 +19,9 @@ broker-vhost:
     - require:
       - rabbitmq_user: broker-user
 
-queue_firewall:
 {% for host, ifaces in salt['mine.get']('roles:web|worker', 'network.interfaces', expr_form='grain_pcre').items() %}
 {% set host_addr = vars.get_primary_ip(ifaces) %}
+queue_allow-{{ host_addr }}:
   ufw.allow:
     - name: '5672'
     - enabled: true

--- a/conf/salt/project/web/app.sls
+++ b/conf/salt/project/web/app.sls
@@ -35,9 +35,9 @@ gunicorn_process:
     - require:
       - file: gunicorn_conf
 
-app_firewall:
 {% for host, ifaces in salt['mine.get']('roles:balancer', 'network.interfaces', expr_form='grain_pcre').items() %}
 {% set host_addr = vars.get_primary_ip(ifaces) %}
+app_allow-{{ host_addr }}:
   ufw.allow:
     - name: '8000'
     - enabled: true


### PR DESCRIPTION
@calebsmith ran into this problem when you need to allow multiple IPs. The state cannot have multiple `ufw.allow` statements. Instead this creates multiple states which are uniquely named for the IP.
