### PR TITLE
Make venv owned by project user

### DIFF
--- a/conf/salt/project/venv.sls
+++ b/conf/salt/project/venv.sls
@@ -13,6 +13,7 @@ venv:
   virtualenv.managed:
     - name: {{ vars.venv_dir }}
     - python: {{ '/usr/bin/python' ~ pillar['python_version'] }}
+    - user: {{ pillar['project_name'] }}
     - require:
       - pip: virtualenv
       - file: root_dir
@@ -31,17 +32,6 @@ pip_requirements:
     - upgrade: true
     - require:
       - virtualenv: venv
-
-venv_dir:
-  file.directory:
-    - name: {{ vars.venv_dir }}
-    - user: {{ pillar['project_name'] }}
-    - group: {{ pillar['project_name'] }}
-    - recurse:
-      - user
-      - group
-    - require:
-      - pip: pip_requirements
 
 project_path:
   file.managed:


### PR DESCRIPTION
On some occasions, salt is unable to recurse over the venv dir and chown/chgrp to the project user. This removes the file.directory state and instead makes the venv owned by the project user.

Do not merge yet as I haven't yet tested that this works.
