### PR TITLE
make clear that developer ssh keys need to be placed under "users:" parent

### DIFF
--- a/conf/pillar/devs.sls
+++ b/conf/pillar/devs.sls
@@ -1,5 +1,5 @@
+# This should be a list of developer users and their public SSH keys
 users:
-  # This should be a list of developer users and their public SSH keys
   # example-user:
   #   public_key:
   #     - ssh-dss AAAAB3NzaC1kc3MAAACBAP/dCNcAJED+pBsEwH01E4NU2xrvoB6H5gXkvQHWIKUuMF3MWXgSGhKpgVqLJKh+d0gwuKyI9344HM5dFs4z3E0JhI7Fg4uXIYu1SwuqnxO+D18WLVGt4gCn57JCjLy/c8LJWAHJWFb2v9t4fayC+oBiyEvpjI6VYIJnSvO3D4tjAAAAFQCNzcKi0sehN1Jw+zB6ccMlHt5E6wAAAIEAnW18UHG/O+RIkJazTJ7qFlOb79RS1nnvnHAvtfuiAPIBmeJcKoZkiQzeBYtFereSRHmSug9DsqHK6C5PrP36UMZYhDkqqp5gpJexmokI2kt3AVxJwro7cjy6Tq+0yt+lwqH4JEblybk7yPeRNC1ihnp2CSipC5LP1PydIcgN9/UAAACAeH1OxUzgCfpM06cfKL57gtjIS34ryCdkT2oYfYOANa8vahN2JqxB004o+z2CnQ9DkTqzzf9jUYI/qal19+zYhn8Bd/FdPVp+VTfRpR17fQKuTWrnF7g6jNVN2ltwHo6o99vrCzjHhJHZ2EXOODzAUrACptyfQv/ZCutkjAg44YE= copelco@montgomery.local

--- a/docs/provisioning.rst
+++ b/docs/provisioning.rst
@@ -64,7 +64,7 @@ For the environment you want to setup you will need to set the ``domain`` in
 ``conf/pillar/<environment>/env.sls``.
 
 You will also need add the developer's user names and SSH keys to ``conf/pillar/devs.sls``. Each
-user record should match the format::
+user record (under the parent ``users:`` key) should match the format::
 
     example-user:
       public_key:


### PR DESCRIPTION
I missed this the first time I set up the template. A small issue, but it took me awhile to figure out what was going on.

Some other ideas @mlavin mentioned that we could also consider if something less reliant on documentation is desired:

> We could make the state fail if there are no devs. I'm not strickly opposed to that but it's probably not going to give an easy to understand message in this case. It's most likely just going to KeyError on missing users.
> 
> Another approach would be to automate adding your own key to the users via a fab command (fab add_to_devs). I could default the username and ssh key location but also take them as parameters.
