### PR TITLE
Ignore anything that looks like a secrets file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@
 */settings/local.py
 public/static/
 public/media/
-secrets.sls
+secrets.sls*


### PR DESCRIPTION
Like the secrets.sls.bak files created during deployment, which git status keeps suggesting I might want to add. I don't.
