### PR TITLE
Force overwrite of local changes in git.latest

### DIFF
--- a/conf/salt/project/repo.sls
+++ b/conf/salt/project/repo.sls
@@ -32,6 +32,7 @@ project_repo:
     - name: "{{ pillar['repo']['url'] }}"
     - rev: "{{ pillar['repo'].get('branch', 'master') }}"
     - target: {{ vars.source_dir }}
+    - force_checkout: True
     - user: {{ pillar['project_name'] }}
     {% if 'github_deploy_key' in pillar %}
     - identity: "/home/{{ pillar['project_name'] }}/.ssh/github"


### PR DESCRIPTION
I tested this on ccj first and it did over-write local changes to both files that needed to be overwritten and those that did not. Without this local mods on the servers survive deploys; if a deploy would over-write a file with a local mod the deploy fails until the local mod is removed. Since there should not be local mods done on the server it's better to my mind to always over-write them.
