### PR TITLE
Allow for multiple users/pws in http_auth secrets

### DIFF
--- a/conf/salt/project/web/balancer.sls
+++ b/conf/salt/project/web/balancer.sls
@@ -49,15 +49,24 @@ apache2-utils:
   pkg:
     - installed
 
+clear_auth_file:
+  file.absent:
+    - name: {{ auth_file }}
+    - require:
+      - file: root_dir
+      - pkg: apache2-utils
+
 auth_file:
   cmd.run:
     - names:
 {%- for key, value in pillar['http_auth'].items() %}
-      - htpasswd {% if loop.first -%}-c{%- endif %} -bd {{ auth_file }} {{ key }} {{ value }}
+      - htpasswd -bd {{ auth_file }} {{ key }} {{ value }}
 {% endfor %}
     - require:
       - pkg: apache2-utils
       - file: root_dir
+      - file: clear_auth_file
+      - file: {{ auth_file }}
 
 {{ auth_file }}:
   file.managed:
@@ -66,7 +75,7 @@ auth_file:
     - mode: 640
     - require:
       - file: root_dir
-      - cmd: auth_file
+      - file: clear_auth_file
 {% endif %}
 
 nginx_conf:


### PR DESCRIPTION
- cmd.run names property appears to be inconsistent. It seems as if
  there is no guarantee that salt executes the commands in the same
  order as the template for loop
- explicitly clear auth_file prior to running htpasswd so reliance
  on cmd.run order is not necessary

(Fix proposed by Pesach , one of our ccj tenthwave collaborators.)
