### PR TITLE
Python Version Configuration

### DIFF
--- a/conf/salt/project/venv.sls
+++ b/conf/salt/project/venv.sls
@@ -3,11 +3,16 @@
 include:
   - project.dirs
   - project.repo
-  {% if pillar['python_version'] > 3 %}
-  - python.33
-  {% else %}
-  - python.27
-  {% endif %}
+  - python
+
+python-pkgs:
+  pkg:
+    - installed
+    - names:
+      - python{{ pillar['python_version'] }}
+      - python{{ pillar['python_version'] }}-dev
+    - require:
+      - pkgrepo: deadsnakes
 
 venv:
   virtualenv.managed:


### PR DESCRIPTION
Fixes #118. This is based on @copelco's example and makes it easier to use Python 3.4 not just 2.7 or 3.3.
