### PR TITLE
Increase timeout from 5 (default) to 60 sec.

### DIFF
--- a/conf/master.conf
+++ b/conf/master.conf
@@ -1,3 +1,5 @@
+timeout: 60
+
 state_output: mixed
 
 fileserver_backend:


### PR DESCRIPTION
Hopefully will eliminate problems with deploy simply exiting with
no output. Thanks to Vinod for finding this!
