### PR TITLE
Add ghostscript as a required package.

### DIFF
--- a/conf/salt/project/venv.sls
+++ b/conf/salt/project/venv.sls
@@ -46,3 +46,6 @@ project_path:
     - group: {{ pillar['project_name'] }}
     - require:
       - pip: pip_requirements
+
+ghostscript:
+  pkg.installed


### PR DESCRIPTION
Pillow uses ghostscript to manipulate eps images. Without ghostscript
being installed an obscure "OSError: [Errno 2] No such file or directory"
is raised on attempts to manipulate eps images. Since Pillow is among our
default pip-installed packages we should ensure this utility is there
always as well.
