### PR TITLE
migrate command references missing `syncdb` command

### DIFF
--- a/conf/salt/project/web/app.sls
+++ b/conf/salt/project/web/app.sls
@@ -88,5 +88,5 @@ migrate:
     - group: {{ pillar['project_name'] }}
     - onlyif: "{{ vars.path_from_root('manage.sh') }} migrate --list | grep '\\[ \\]'"
     - require:
-      - cmd: syncdb
+      - file: manage
     - order: last


### PR DESCRIPTION
```
[ec2-54-137-116-37.compute-1.amazonaws.com] out: ----------
[ec2-54-137-116-37.compute-1.amazonaws.com] out:           ID: migrate
[ec2-54-137-116-37.compute-1.amazonaws.com] out:     Function: cmd.run
[ec2-54-137-116-37.compute-1.amazonaws.com] out:         Name: /var/www/school_absenteeism/manage.sh migrate --noinput
[ec2-54-137-116-37.compute-1.amazonaws.com] out:       Result: False
[ec2-54-137-116-37.compute-1.amazonaws.com] out:      Comment: The following requisites were not found:
[ec2-54-137-116-37.compute-1.amazonaws.com] out:                                  require:
[ec2-54-137-116-37.compute-1.amazonaws.com] out:                                      cmd: syncdb
[ec2-54-137-116-37.compute-1.amazonaws.com] out:      Changes:   
```

See: https://github.com/caktus/django-project-template/blob/master/conf/salt/project/web/app.sls#L84

This is using Django 1.7 and the latest project template.
