### PR TITLE
Require ALLOWED_HOSTS on staging

### DIFF
--- a/conf/salt/project/django/manage.sh
+++ b/conf/salt/project/django/manage.sh
@@ -1,6 +1,6 @@
 # Shell script to setup necessary environment variables and run a management command
 export DJANGO_SETTINGS_MODULE={{ settings }}
-export ALLOWED_HOST={{ pillar['domain'] }}
+export ALLOWED_HOSTS={{ pillar['domain'] }}
 {% for key, value in pillar.get('secrets', {}).items() + pillar.get('env', {}).items() %}
 export {{ key }}='{{ value }}'
 {% endfor %}

--- a/conf/salt/project/worker/celery.conf
+++ b/conf/salt/project/worker/celery.conf
@@ -13,7 +13,7 @@ startsecs=1
 ; Need to wait for currently executing tasks to finish at shutdown.
 ; Increase this if you have very long running tasks.
 stopwaitsecs=60
-environment=DJANGO_SETTINGS_MODULE="{{ settings }}",
+environment=DJANGO_SETTINGS_MODULE="{{ settings }}",ALLOWED_HOSTS="{{ pillar['domain'] }}",
     {%- for key, value in pillar.get('secrets', {}).items() + pillar.get('env', {}).items() -%}
         {{ key }}="{{ value }}"{%- if not loop.last -%},{%- endif -%}
     {%- endfor -%}

--- a/project_name/settings/staging.py
+++ b/project_name/settings/staging.py
@@ -37,7 +37,7 @@ SESSION_COOKIE_SECURE = True
 
 SESSION_COOKIE_HTTPONLY = True
 
-ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', '').split(';')
+ALLOWED_HOSTS = os.environ['ALLOWED_HOSTS'].split(';')
 
 # Uncomment if using celery worker configuration
 # CELERY_SEND_TASK_ERROR_EMAILS = True


### PR DESCRIPTION
This PR enforces that ALLOWED_HOSTS be set in the staging environment before
it allows the server to start up. There are 3 places where that env setting
must be present (gunicorn, celery, and our manage.sh script)
