### PR TITLE
Rsync local files

### DIFF
--- a/conf/salt/project/venv.sls
+++ b/conf/salt/project/venv.sls
@@ -22,11 +22,7 @@ venv:
     - require:
       - pip: virtualenv
       - file: root_dir
-      {% if grains['environment'] == 'local' %}
       - file: project_repo
-      {% else %}
-      - cmd: delete_pyc
-      {% endif %}
       - pkg: python-pkgs
       - pkg: python-headers
 


### PR DESCRIPTION
Instead of symlinking /vagrant to /var/www/PROJECT/source. This
way the project user can own the files and write to them.

We might want to not include --delete on the rsync command, though,
since that'll remove any files added to the source tree that
aren't in /vagrant, like log files.

Branch: rsync-local-files