### PR TITLE
Trusty Updates

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,3 +1,5 @@
+Vagrant.require_version ">= 1.7.0"
+
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/trusty64"
   config.vm.network :private_network, ip: "33.33.33.10"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,5 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "precise32"
-  config.vm.box_url = "http://files.vagrantup.com/precise32.box"
+  config.vm.box = "ubuntu/trusty64"
   config.vm.network :private_network, ip: "33.33.33.10"
   config.vm.provider :virtualbox do |vbox|
     vbox.customize ["modifyvm", :id, "--memory", "1024"]
@@ -8,8 +7,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.synced_folder "conf/", "/srv/"
 
-  config.vm.provision :shell, :inline => "sudo apt-get install python-pip git-core -qq -y"
-  config.vm.provision :shell, :inline => "sudo pip install -q -U GitPython"
+  config.vm.provision :shell, :inline => "sudo apt-get install python-pip git-core python-git -qq -y"
 
   config.vm.provision :salt do |salt|
 

--- a/docs/vagrant.rst
+++ b/docs/vagrant.rst
@@ -6,7 +6,7 @@ Starting the VM
 ------------------------
 
 You can test the provisioning/deployment using `Vagrant <http://vagrantup.com/>`_. This requires
-Vagrant 1.3+. The Vagrantfile is configured to install the Salt Master and Minion inside the VM once
+Vagrant 1.7+. The Vagrantfile is configured to install the Salt Master and Minion inside the VM once
 you've run ``vagrant up``. The box will be installed if you don't have it already.::
 
     vagrant up

--- a/fabfile.py
+++ b/fabfile.py
@@ -64,8 +64,7 @@ def setup_master():
         with hide('running', 'stdout', 'stderr'):
             installed = run('which git')
     if not installed:
-        sudo('apt-get install python-pip git-core -qq -y')
-        sudo('pip install -q -U GitPython')
+        sudo('apt-get install python-pip git-core python-git -qq -y')
     put(local_path='conf/master.conf', remote_path="/etc/salt/master", use_sudo=True)
     sudo('service salt-master restart')
 


### PR DESCRIPTION
See #88. This changes the Vagrant box to using Trusty rather than Precise. Some minor adjustments related to installing `GitPython`. Doesn't yet address the biggest issue with 14.04 which is the Posgres version. That will have to be addressed in #117.