### PR TITLE
Update defaults to use Postgres 9.3 rather than 9.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ local development system::
 - `pip <http://www.pip-installer.org/>`_ >= 1.5
 - `virtualenv <http://www.virtualenv.org/>`_ >= 1.10
 - `virtualenvwrapper <http://pypi.python.org/pypi/virtualenvwrapper>`_ >= 3.0
-- Postgres >= 9.1
+- Postgres >= 9.3
 - git >= 1.7
 
 

--- a/conf/pillar/project.sls
+++ b/conf/pillar/project.sls
@@ -4,3 +4,5 @@ project_name: example
 python_version: 2.7
 
 less_version: 2.1.0
+
+postgres_version: 9.3

--- a/conf/salt/project/db/init.sls
+++ b/conf/salt/project/db/init.sls
@@ -1,5 +1,7 @@
 {% import 'project/_vars.sls' as vars with context %}
 
+{% set pg_version = salt['pillar.get']('postgres_version', '9.3') %}
+
 include:
   - postgresql
   - ufw
@@ -31,13 +33,14 @@ database-{{ pillar['project_name'] }}:
 
 hba_conf:
   file.managed:
-    - name: /etc/postgresql/9.1/main/pg_hba.conf
+    - name: /etc/postgresql/{{ pg_version }}/main/pg_hba.conf
     - source: salt://project/db/pg_hba.conf
     - user: postgres
     - group: postgres
     - mode: 0640
     - template: jinja
     - context:
+        version: {{ pg_version }}
         servers:
 {%- for host, ifaces in vars.app_minions.items() %}
 {% set host_addr = vars.get_primary_ip(ifaces) %}
@@ -51,12 +54,14 @@ hba_conf:
 
 postgresql_conf:
   file.managed:
-    - name: /etc/postgresql/9.1/main/postgresql.conf
+    - name: /etc/postgresql/{{ pg_version }}/main/postgresql.conf
     - source: salt://project/db/postgresql.conf
     - user: postgres
     - group: postgres
     - mode: 0644
     - template: jinja
+    - context:
+        version: {{ pg_version }}
     - require:
       - pkg: postgresql
       - cmd: /var/lib/postgresql/configure_utf-8.sh

--- a/conf/salt/project/db/init.sls
+++ b/conf/salt/project/db/init.sls
@@ -40,7 +40,7 @@ hba_conf:
     - mode: 0640
     - template: jinja
     - context:
-        version: {{ pg_version }}
+        version: "{{ pg_version }}"
         servers:
 {%- for host, ifaces in vars.app_minions.items() %}
 {% set host_addr = vars.get_primary_ip(ifaces) %}
@@ -61,7 +61,7 @@ postgresql_conf:
     - mode: 0644
     - template: jinja
     - context:
-        version: {{ pg_version }}
+        version: "{{ pg_version }}"
     - require:
       - pkg: postgresql
       - cmd: /var/lib/postgresql/configure_utf-8.sh

--- a/conf/salt/project/db/postgresql.conf
+++ b/conf/salt/project/db/postgresql.conf
@@ -38,15 +38,15 @@
 # The default values of these variables are driven from the -D command-line
 # option or PGDATA environment variable, represented here as ConfigDir.
 
-data_directory = '/var/lib/postgresql/9.1/main'     # use data in another directory
+data_directory = '/var/lib/postgresql/{{ version }}/main'     # use data in another directory
                     # (change requires restart)
-hba_file = '/etc/postgresql/9.1/main/pg_hba.conf'   # host-based authentication file
+hba_file = '/etc/postgresql/{{ version }}/main/pg_hba.conf'   # host-based authentication file
                     # (change requires restart)
-ident_file = '/etc/postgresql/9.1/main/pg_ident.conf'   # ident configuration file
+ident_file = '/etc/postgresql/{{ version }}/main/pg_ident.conf'   # ident configuration file
                     # (change requires restart)
 
 # If external_pid_file is not explicitly set, no extra PID file is written.
-external_pid_file = '/var/run/postgresql/9.1-main.pid'      # write an extra PID file
+external_pid_file = '/var/run/postgresql/{{ version }}-main.pid'      # write an extra PID file
                     # (change requires restart)
 
 
@@ -65,7 +65,11 @@ max_connections = {{ salt['pillar.get']('postgresql_config:max_connections', '10
 # Note:  Increasing max_connections costs ~400 bytes of shared memory per
 # connection slot, plus lock space (see max_locks_per_transaction).
 #superuser_reserved_connections = 3 # (change requires restart)
+{% if version >= '9.3' %}
+unix_socket_directories = '/var/run/postgresql'       # (change requires restart)
+{% else %}
 unix_socket_directory = '/var/run/postgresql'       # (change requires restart)
+{% endif %}
 #unix_socket_group = ''         # (change requires restart)
 #unix_socket_permissions = 0777     # begin with 0 to use octal notation
                     # (change requires restart)
@@ -81,6 +85,10 @@ ssl = true              # (change requires restart)
 #ssl_ciphers = 'ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH'  # allowed SSL ciphers
                     # (change requires restart)
 #ssl_renegotiation_limit = 512MB    # amount of data between renegotiations
+{% if version >= '9.3' %}
+ssl_cert_file = '/etc/ssl/certs/ssl-cert-snakeoil.pem'          # (change requires restart)
+ssl_key_file = '/etc/ssl/private/ssl-cert-snakeoil.key'         # (change requires restart)
+{% endif %}
 #password_encryption = on
 #db_user_namespace = off
 


### PR DESCRIPTION
Deployments have been using 14.04 for over a year and I can't count the number of times I've had to make this update.