### PR TITLE
Remove duplicate port 80 server definition

### DIFF
--- a/conf/salt/project/web/site.conf
+++ b/conf/salt/project/web/site.conf
@@ -72,10 +72,3 @@ server {
         proxy_pass http://{{ pillar['project_name'] }};
     }
 }
-
-{# redirect other server names to the real one (http://nginx.org/en/docs/http/converting_rewrite_rules.html under "A redirect to a main site") #}
-server {
-    listen 80 default_server;
-    server_name _;
-    return 301 https://{{ pillar['domain'] }}$request_uri;
-}


### PR DESCRIPTION
There's one near the top of site.conf that redirects to port
443. The one farther down is redundant.

Branch: fix_duplicate_server_defn