### PR TITLE
Use npm salt state to install less

### DIFF
--- a/conf/salt/project/web/app.sls
+++ b/conf/salt/project/web/app.sls
@@ -55,23 +55,13 @@ app_allow-{{ host_addr }}:
       - pkg: ufw
 {% endfor %}
 
-node_ppa:
-  pkgrepo.managed:
-    - ppa: chris-lea/node.js
-
-nodejs:
-  pkg.installed:
-    - require:
-      - pkgrepo: node_ppa
-    - refresh: True
+npm:
+  pkg.installed
 
 less:
-  cmd.run:
-    - name: npm install less@{{ pillar['less_version'] }} -g
-    - user: root
-    - unless: "which lessc && lessc --version | grep {{ pillar['less_version'] }}"
+  npm.installed:
     - require:
-      - pkg: nodejs
+      - pkg: npm
 
 collectstatic:
   cmd.run:

--- a/conf/salt/project/web/app.sls
+++ b/conf/salt/project/web/app.sls
@@ -55,13 +55,20 @@ app_allow-{{ host_addr }}:
       - pkg: ufw
 {% endfor %}
 
-npm:
-  pkg.installed
+node-pkgs:
+  pkg:
+    - installed
+    - names:
+      - npm
+      - nodejs-legacy
 
-less@{{ pillar['less_version'] }}:
-  npm.installed:
+less:
+  cmd.run:
+    - name: npm install less@{{ pillar['less_version'] }} -g
+    - user: root
+    - unless: "which lessc && lessc --version | grep {{ pillar['less_version'] }}"
     - require:
-      - pkg: npm
+      - pkg: node-pkgs
 
 collectstatic:
   cmd.run:

--- a/conf/salt/project/web/app.sls
+++ b/conf/salt/project/web/app.sls
@@ -58,7 +58,7 @@ app_allow-{{ host_addr }}:
 npm:
   pkg.installed
 
-less:
+less@{{ pillar['less_version'] }}:
   npm.installed:
     - require:
       - pkg: npm


### PR DESCRIPTION
This:
1. Removes the chris-lea PPA (which has been deprecated). I didn't replace it with the nodesource PPA, since Ubuntu's default versions seem adequate (nodejs=v0.10.25, npm=1.3.10)
2. Uses the new(ish) salt state to install less

Addresses caktus/margarita#46 and #163 