### PR TITLE
make sure salt-minion gets installed properly

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -91,6 +91,11 @@ def install_salt(version, master=False, minion=False, restart=True):
             # Already installed - if Ubuntu package, uninstall current version first
             # because we're going to do a git install later
             sudo("apt-get remove salt-master -yq")
+        elif not install_minion and not files.exists("/etc/init/salt-minon.conf", use_sudo=True):
+            # setup_master() installs salt-minion, but not the salt-minion
+            # upstart service, so if the upstart file is missing, we still
+            # want to install the minion below
+            install_minion = True
         if restart and not install_master:
             sudo("service salt-master restart")
 


### PR DESCRIPTION
``fab setup_minon`` never runs the ``install_salt.sh`` script to fully install the ``salt-minion``. This is due to ``setup_master`` actually installing the ``/usr/bin/salt-minion`` script, even though it passes the [-N flag](https://github.com/caktus/django-project-template/blob/master/fabfile.py#L113-L114) to the bootstrap script (supposedly this [doesn't install salt-minon](https://github.com/saltstack/salt-bootstrap/blob/develop/bootstrap-salt.sh#L258)). ``fab install_salt``, when run via ``fab salt_minion``, uses ``salt-minion --version`` to decide whether or not to install, which returns a version because it's already installed by the time you're attempting to install ``salt-minion``.

I'm not sure my proposed change is the best solution, but it worked for me today. I find it odd that salt-minion gets installed when you tell it not to, but maybe I don't fully understand the bootstrap script.