### PR TITLE
Open firewall ports on salt-master systems

### DIFF
--- a/conf/salt/salt/master.sls
+++ b/conf/salt/salt/master.sls
@@ -1,0 +1,10 @@
+include:
+  - ufw
+
+ports:
+  ufw.allow:
+    - enabled: true
+    - proto: tcp
+    - names:
+       - '4505'
+       - '4506'

--- a/conf/salt/top.sls
+++ b/conf/salt/top.sls
@@ -9,6 +9,9 @@ base:
   'environment:local':
     - match: grain
     - vagrant.user
+  'roles:salt-master':
+    - match: grain
+    - salt.master
   'roles:web':
     - match: grain
     - project.web.app


### PR DESCRIPTION
This was over-enthusiastically removed when cleaning up
unneeded salt references.

Branch: keep_some_salt