### PR TITLE
Add P3P to mitigate IE issues

### DIFF
--- a/conf/salt/project/web/site.conf
+++ b/conf/salt/project/web/site.conf
@@ -69,6 +69,7 @@ server {
         proxy_redirect off;
         proxy_buffering on;
         proxy_intercept_errors on;
+        add_header P3P 'CP="Hello IE"';
         proxy_pass http://{{ pillar['project_name'] }};
     }
 }


### PR DESCRIPTION
We ran across an issue in Pressweb; @mlavin found a good summary of the issue here https://github.com/mozilla/vinz-clortho/issues/105 and dug up conf he utilizes on another site to resolve the issue.

 * add nginx conf to add P3P header to work around IE issues.

