### PR TITLE
Move Common Middleware after Session Middleware

### DIFF
--- a/project_name/settings/base.py
+++ b/project_name/settings/base.py
@@ -93,8 +93,8 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 )
 
 MIDDLEWARE_CLASSES = (
-    'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',


### PR DESCRIPTION
I'm not sure if this makes a practical difference, but the default `startproject` command uses this [order](https://docs.djangoproject.com/en/1.8/topics/http/middleware/#activating-middleware) and if you decide to add LocaleMiddleware, its [docs](https://docs.djangoproject.com/en/1.8/topics/i18n/translation/#how-django-discovers-language-preference) say to put LocaleMiddleware after Session and before Common.