### PR TITLE
Update to latest version of margarita

### DIFF
--- a/conf/salt/margarita.sls
+++ b/conf/salt/margarita.sls
@@ -5,7 +5,7 @@ git-install:
 project_repo:
   git.latest:
     - name: https://github.com/caktus/margarita.git
-    - rev: 1.0.1
+    - rev: 1.0.3
     - force: true
     - target: /srv/margarita
     - user: root


### PR DESCRIPTION
Opinions on whether this should point to the latest release or to master?

The benefit of fixing it to the latest release is that projects can decide to upgrade on their own, rather than whenever margarita updates. The downside is that we need to remember to update this every time we have a new margarita release, so that new projects get the latest release.

If we agree on 'latest release', then I can add docs to the margarita release process to update this setting after each release.