### PR TITLE
Explicitly expose domain in environment

### DIFF
--- a/conf/salt/project/django/manage.sh
+++ b/conf/salt/project/django/manage.sh
@@ -1,6 +1,6 @@
 # Shell script to setup necessary environment variables and run a management command
 export DJANGO_SETTINGS_MODULE='{{ settings }}'
-export ALLOWED_HOSTS='{{ pillar["domain"] }}'
+export DOMAIN='{{ pillar["domain"] }}'
 export ENVIRONMENT='{{ pillar["environment"] }}'
 {% for key, value in pillar.get('secrets', {}).items() + pillar.get('env', {}).items() %}
 export {{ key }}='{{ value }}'

--- a/conf/salt/project/web/gunicorn.conf
+++ b/conf/salt/project/web/gunicorn.conf
@@ -10,7 +10,7 @@ stopwaitsecs=60
 stdout_logfile={{ log_dir }}/gunicorn.log
 redirect_stderr=true
 stderr_logfile={{ log_dir }}/gunicorn.error.log
-environment=DJANGO_SETTINGS_MODULE="{{ settings }}",ENVIRONMENT="{{ pillar['environment'] }}",ALLOWED_HOSTS="{{ pillar['domain'] }}",
+environment=DJANGO_SETTINGS_MODULE="{{ settings }}",ENVIRONMENT="{{ pillar['environment'] }}",DOMAIN="{{ pillar['domain'] }}",
     {%- for key, value in pillar.get('secrets', {}).items() + pillar.get('env', {}).items() -%}
         {{ key }}="{{ value }}"{%- if not loop.last -%},{%- endif -%}
     {%- endfor -%}

--- a/conf/salt/project/worker/celery.conf
+++ b/conf/salt/project/worker/celery.conf
@@ -13,7 +13,7 @@ startsecs=1
 ; Need to wait for currently executing tasks to finish at shutdown.
 ; Increase this if you have very long running tasks.
 stopwaitsecs=60
-environment=DJANGO_SETTINGS_MODULE="{{ settings }}",ENVIRONMENT="{{ pillar['environment'] }}",ALLOWED_HOSTS="{{ pillar['domain'] }}",
+environment=DJANGO_SETTINGS_MODULE="{{ settings }}",ENVIRONMENT="{{ pillar['environment'] }}",DOMAIN="{{ pillar['domain'] }}",
     {%- for key, value in pillar.get('secrets', {}).items() + pillar.get('env', {}).items() -%}
         {{ key }}="{{ value }}"{%- if not loop.last -%},{%- endif -%}
     {%- endfor -%}

--- a/project_name/settings/deploy.py
+++ b/project_name/settings/deploy.py
@@ -33,6 +33,8 @@ CACHES = {
 }
 
 EMAIL_SUBJECT_PREFIX = '[{{ project_name|title }} %s] ' % ENVIRONMENT.title()
+DEFAULT_FROM_EMAIL = 'noreply@%(DOMAIN)s' % os.environ
+SERVER_EMAIL = DEFAULT_FROM_EMAIL
 
 COMPRESS_ENABLED = True
 
@@ -40,7 +42,7 @@ SESSION_COOKIE_SECURE = True
 
 SESSION_COOKIE_HTTPONLY = True
 
-ALLOWED_HOSTS = os.environ['ALLOWED_HOSTS'].split(';')
+ALLOWED_HOSTS = os.environ['DOMAIN'].split(';')
 
 # Uncomment if using celery worker configuration
 # CELERY_SEND_TASK_ERROR_EMAILS = True


### PR DESCRIPTION
I wanted to add `DEFAULT_FROM_EMAIL` to our settings, but in a DRY way, so
I needed access to `pillar["domain"]`. I saw it was already there for
the `ALLOWED_HOSTS` variable.

This PR does 2 things:

1. Changes the env var `ALLOWED_HOSTS` to be named `DOMAIN`.
2. Adds `DEFAULT_FROM_EMAIL` and `SERVER_EMAIL` to our settings.