### PR TITLE
Read environment vars from .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ public/static/
 public/media/
 conf/pillar/*/deploy
 *.priv
+.env

--- a/README.rst
+++ b/README.rst
@@ -38,16 +38,13 @@ necessary requirements::
     $ mkvirtualenv {{ project_name }} -p `which python3.4`
     ({{ project_name }})$ $VIRTUAL_ENV/bin/pip install -r $PWD/requirements/dev.txt
 
-Then create a local settings file and set your ``DJANGO_SETTINGS_MODULE`` to use it::
+Next, we'll set up our local environment variables. We use `django-dotenv
+<https://github.com/jpadilla/django-dotenv>`_ to help with this. It reads environment variables
+located in a file name ``.env`` in the top level directory of the project. The only variable we need
+to start is ``DJANGO_SETTINGS_MODULE``::
 
     ({{ project_name }})$ cp {{ project_name }}/settings/local.example.py {{ project_name }}/settings/local.py
-    ({{ project_name }})$ echo "export DJANGO_SETTINGS_MODULE={{ project_name }}.settings.local" >> $VIRTUAL_ENV/bin/postactivate
-    ({{ project_name }})$ echo "unset DJANGO_SETTINGS_MODULE" >> $VIRTUAL_ENV/bin/postdeactivate
-
-Exit the virtualenv and reactivate it to activate the settings just changed::
-
-    ({{ project_name }})$ deactivate
-    $ workon {{ project_name }}
+    ({{ project_name }})$ echo "DJANGO_SETTINGS_MODULE={{ project_name }}.settings.local" > .env
 
 Create the Postgres database and run the initial migrate::
 

--- a/manage.py
+++ b/manage.py
@@ -2,6 +2,9 @@
 import os
 import sys
 
+import dotenv
+dotenv.read_dotenv()
+
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ project_name }}.settings")
 

--- a/project_name/wsgi.py
+++ b/project_name/wsgi.py
@@ -12,7 +12,7 @@ import os
 from django.core.wsgi import get_wsgi_application
 
 import dotenv
-dotenv.read_dotenv(os.path.join(os.path.dirname(os.path.dirname(__file__)), '.env'))
+dotenv.read_dotenv(os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, '.env')))
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ project_name }}.settings")
 

--- a/project_name/wsgi.py
+++ b/project_name/wsgi.py
@@ -8,11 +8,14 @@ https://docs.djangoproject.com/en/{{ docs_version }}/howto/deployment/wsgi/
 """
 
 import os
+from os.path import dirname, join
 
 from django.core.wsgi import get_wsgi_application
 
 import dotenv
-dotenv.read_dotenv(os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, '.env')))
+
+project_dir = dirname(dirname(__file__))
+dotenv.read_dotenv(join(project_dir, '.env'))
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ project_name }}.settings")
 

--- a/project_name/wsgi.py
+++ b/project_name/wsgi.py
@@ -11,6 +11,9 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
+import dotenv
+dotenv.read_dotenv(os.path.join(os.path.dirname(os.path.dirname(__file__)), '.env'))
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ project_name }}.settings")
 
 application = get_wsgi_application()

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,3 +7,5 @@ django-appconf==1.0.1
 six==1.9.0
 
 BeautifulSoup4==4.4.0
+
+django-dotenv==1.3.0


### PR DESCRIPTION
Uses django-dotenv to load environment variables from `.env`. It does
this from manage.py (for local runserver use and management commands)
and from wsgi.py (for gunicorn eventually).

Updates the README to remove need for venv postactivate hook.

Adds .env to gitignore.

Addresses #166