### PR TITLE
Use Salt 2015.5.5 to get RabbitMQ fix

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -10,7 +10,7 @@ from fabric.contrib import files, project
 from fabric.utils import abort
 
 DEFAULT_SALT_LOGLEVEL = 'info'
-SALT_VERSION = '2015.5.3'
+SALT_VERSION = '2015.5.5'
 PROJECT_ROOT = os.path.dirname(__file__)
 CONF_ROOT = os.path.join(PROJECT_ROOT, 'conf')
 


### PR DESCRIPTION
Closes #182

We used 2015.5.5 for theirc/rescue_id successfully.