### PR TITLE
Don't use newrelic_webmon state

### DIFF
--- a/conf/salt/top.sls
+++ b/conf/salt/top.sls
@@ -16,12 +16,10 @@ base:
   'roles:web':
     - match: grain
     - project.web.app
-    - project.newrelic_webmon
   'roles:worker':
     - match: grain
     - project.worker.default
     - project.worker.beat
-    - project.newrelic_webmon
   'roles:balancer':
     - match: grain
     - project.web.balancer


### PR DESCRIPTION
It's no longer in Margarita, and not needed.
See Margarita's README for docs on enabling New Relic
for new projects.

This is to address https://github.com/caktus/margarita/issues/80.













Branch: dont_use_newrelic_webmon_state