### PR TITLE
Force SECRET_KEY to be set in the deploy environment

### DIFF
--- a/project_name/settings/base.py
+++ b/project_name/settings/base.py
@@ -15,9 +15,6 @@ import os
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 PROJECT_ROOT = os.path.abspath(os.path.join(BASE_DIR, os.pardir))
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get('SECRET_KEY', '{{ secret_key }}')
-
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 

--- a/project_name/settings/deploy.py
+++ b/project_name/settings/deploy.py
@@ -6,6 +6,8 @@ os.environ.setdefault('BROKER_HOST', '127.0.0.1:5672')
 
 ENVIRONMENT = os.environ['ENVIRONMENT']
 
+SECRET_KEY = os.environ['SECRET_KEY']
+
 DEBUG = False
 
 DATABASES['default']['NAME'] = '{{ project_name }}_%s' % ENVIRONMENT.lower()

--- a/project_name/settings/dev.py
+++ b/project_name/settings/dev.py
@@ -18,6 +18,8 @@ CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 
 COMPRESS_ENABLED = False
 
+SECRET_KEY = os.environ.get('SECRET_KEY', '{{ secret_key }}')
+
 # Special test settings
 if 'test' in sys.argv:
     COMPRESS_PRECOMPILERS = ()


### PR DESCRIPTION
This allows SECRET_KEY to use a hardcoded default for development, but
forces it to be provided in the environment for deployment.

Closes #219