### PR TITLE
Tell Celery to obey our logging configuration

### DIFF
--- a/project_name/settings/base.py
+++ b/project_name/settings/base.py
@@ -192,3 +192,6 @@ STATICFILES_FINDERS = (
 COMPRESS_PRECOMPILERS = (
     ('text/less', 'lessc {infile} {outfile}'),
 )
+
+# If using Celery, tell it to obey our logging configuration.
+CELERYD_HIJACK_ROOT_LOGGER = False


### PR DESCRIPTION
Otherwise Celery does its own thing when running its worker
processes, and we miss notices about exceptions and things
that can happen in those processes.

Branch: fix_celery_breaking_logconfig