### PR TITLE
Use load_env in all places

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -2,8 +2,9 @@
 import os
 import sys
 
-import dotenv
-dotenv.read_dotenv()
+from {{ project_name }} import load_env
+
+load_env.load_env()
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ project_name }}.settings")


### PR DESCRIPTION
We use `load_env` in celery.py and wsgi.py... Makes sense to use it in
manage.py as well