### PR TITLE
*/static/js/vendors.js should be git ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ conf/pillar/*/deploy
 .env
 node_modules
 */static/js/bundle.js
+*/static/js/vendors.js
 */static/css


### PR DESCRIPTION
since vendors.js is generated from dependencies in gulpfile.js, it should be in .gitignore