### PR TITLE
Explicitly invoke python from our virtual env

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -170,7 +170,10 @@ gulp.task('default', function (cb) {
 
   console.log("Starting Django runserver http://"+argv.address+":"+argv.port+"/");
   var args = ["manage.py", "runserver", argv.address+":"+argv.port];
-  var runserver = spawn("python", args, {
+  // Newer versions of npm mess with the PATH, sometimes putting /usr/bin at the front,
+  // so make sure we invoke the python from our virtual env explicitly.
+  var python = process.env['VIRTUAL_ENV'] + '/bin/python';
+  var runserver = spawn(python, args, {
     stdio: "inherit",
   });
   runserver.on('close', function(code) {


### PR DESCRIPTION
In our gulpfile, when starting Django, explicitly
use the Python from our virtual env. This works around
a recent change in npm that can put /usr/bin on the
front of the PATH and mysteriously results in the wrong
Python getting invoked.

Branch: fix_python_path