### PR TITLE
Small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,6 @@ conf/pillar/*/deploy
 .env
 node_modules
 */static/js/bundle.js
+*/static/js/vendor.js
+*/static/libs/modernizr.js
 */static/css

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+python=python2.7


### PR DESCRIPTION
* Adding .npmrc file to tell npm to use python2.7 when installing dependencies. Fixes broken node-gyp builds.
* Adding `coverage` plus a couple of dist `.js` files to `.gitignore`.