### PR TITLE
Exclude node_modules from flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length=100
-exclude=migrations,docs
+exclude=migrations,docs,node_modules


### PR DESCRIPTION
1) Speeds up flake8
2) Some NPM modules include Python code, which Flake8 might not like