### PR TITLE
Update requirements to list npm separately

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,7 @@ local development system:
 
 - Python >= 3.5
 - NodeJS >= 4.2
+- npm >= 2.14.7
 - `pip <http://www.pip-installer.org/>`_ >= 1.5
 - `virtualenv <http://www.virtualenv.org/>`_ >= 1.10
 - `virtualenvwrapper <http://pypi.python.org/pypi/virtualenvwrapper>`_ >= 3.0


### PR DESCRIPTION
When I installed NodeJS on Ubuntu 16.04, npm was not automatically included, and I had to manually install it. I put a minimum version of 2.14.7 as that is the version that NodeJS version 4.2 uses.
