### PR TITLE
remove unneccesary database creation by travis

### DIFF
--- a/project.travis.yml
+++ b/project.travis.yml
@@ -28,7 +28,6 @@ install:
   - npm install
 
 before_script:
-  - createdb -E UTF-8 {{ project_name }} -U postgres -O $USER
   # Uncomment for Requires.IO pushes of develop and master merges (not pull-request builds)
   # Requires the $REQUIRES_IO_TOKEN environment variable defined at Travis CI for this project
   # See developer documentation section on depdency tracking for more information.


### PR DESCRIPTION
While working on a different project, travis suddenly began failing because it no longer had the `USER` variable set. According to [travis documentation](https://docs.travis-ci.com/user/environment-variables#Default-Environment-Variables), we shouldn't rely on this variable.

It doesn't seem necessary (as pointed out by @vkurup ) to create the database in travis right before running tests, since the tests themselves create a test database, so I have removed the line to create a database by travis.