### PR TITLE
put working createdb back in travisfile - needed for makemigrations

### DIFF
--- a/project.travis.yml
+++ b/project.travis.yml
@@ -28,6 +28,7 @@ install:
   - npm install
 
 before_script:
+  - createdb -E UTF-8 {{ project_name }} -U postgres -O `whoami`
   # Uncomment for Requires.IO pushes of develop and master merges (not pull-request builds)
   # Requires the $REQUIRES_IO_TOKEN environment variable defined at Travis CI for this project
   # See developer documentation section on depdency tracking for more information.

--- a/project.travis.yml
+++ b/project.travis.yml
@@ -28,7 +28,7 @@ install:
   - npm install
 
 before_script:
-  - createdb -E UTF-8 {{ project_name }} -U postgres -O `whoami`
+  - createdb --encoding=UTF-8 {{ project_name }} --username=postgres --owner=`whoami`
   # Uncomment for Requires.IO pushes of develop and master merges (not pull-request builds)
   # Requires the $REQUIRES_IO_TOKEN environment variable defined at Travis CI for this project
   # See developer documentation section on depdency tracking for more information.


### PR DESCRIPTION
It seems that I spoke too soon in #277. While this change worked on the project I tested it on (running Django1.9), it threw an error during the line `python manage.py makemigrations --dry-run | grep 'No changes detected' || (echo 'There are changes which require migrations.' && exit 1)` due to [this line](https://github.com/django/django/blob/master/django/core/management/commands/makemigrations.py#L110) in Django, which was added in Django1.10. Therefore, I conclude that the line to createdb should be required in the travis file, as long as we want the makemigrations command in there as well.

I have changed the reference to the user from `$USER` to `whoami`, which worked during [this deploy] (https://github.com/caktus/caktus-website/pull/1320).
