### PR TITLE
Fix vagrant environment

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,9 +1,9 @@
-Vagrant.require_version ">= 1.7.0"
+Vagrant.require_version ">= 1.8.7"
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "ubuntu/xenial64"
   config.vm.network :private_network, ip: "33.33.33.10"
   config.vm.provider :virtualbox do |vbox|
-    vbox.customize ["modifyvm", :id, "--memory", "1024"]
+    vbox.customize ["modifyvm", :id, "--memory", "2048"]
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,9 +1,9 @@
 Vagrant.require_version ">= 1.8.7"
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "kaorimatz/ubuntu-16.04-amd64"
   config.vm.network :private_network, ip: "33.33.33.10"
   config.vm.provider :virtualbox do |vbox|
-    vbox.customize ["modifyvm", :id, "--memory", "2048"]
+    vbox.customize ["modifyvm", :id, "--memory", "1024"]
   end
 end

--- a/conf/pillar/local.sls
+++ b/conf/pillar/local.sls
@@ -6,3 +6,5 @@ requirements_file: requirements/dev.txt
 
 secrets:
     newrelic_license_key: abcdefg
+    SECRET_KEY: notsosecretbutthatsok
+    DB_PASSWORD: onlyusedlocallyondevlaptop

--- a/conf/pillar/project.sls
+++ b/conf/pillar/project.sls
@@ -7,4 +7,4 @@ less_version: 2.1.0
 
 postgres_version: 9.3
 
-margarita_version: origin/fix-vagrant-username
+margarita_version: 2.1.0

--- a/conf/pillar/project.sls
+++ b/conf/pillar/project.sls
@@ -7,4 +7,4 @@ less_version: 2.1.0
 
 postgres_version: 9.3
 
-margarita_version: 1.6.6
+margarita_version: origin/fix-vagrant-username

--- a/docs/dev/vagrant.rst
+++ b/docs/dev/vagrant.rst
@@ -1,6 +1,17 @@
 Vagrant Testing
 ========================
 
+Quickstart
+------------------------
+
+Here is a one-liner to delete any existing vagrant VM, rebuild it and deploy our code to it. It
+takes about 20-30 minutes on my box. See below for further explanations on what these commands do::
+
+  vagrant destroy && \
+    vagrant up && \
+    fab vagrant setup_master && \
+    fab vagrant setup_minion:salt-master,db-master,cache,web,balancer -H 33.33.33.10 && \
+    fab vagrant deploy
 
 Starting the VM
 ------------------------

--- a/docs/dev/vagrant.rst
+++ b/docs/dev/vagrant.rst
@@ -70,14 +70,16 @@ With the VM fully provisioned and deployed, you can access the VM at the IP addr
 ``Vagrantfile``, which is 33.33.33.10 by default. Since the Nginx configuration will only listen for the domain name in
 ``conf/pillar/local.sls``, you will need to modify your ``/etc/hosts`` configuration to view it
 at one of those IP addresses. I recommend 33.33.33.10, otherwise the ports in the localhost URL cause
-the CSRF middleware to complain ``REASON_BAD_REFERER`` when testing over SSL. You will need to add::
+the CSRF middleware to complain ``REASON_BAD_REFERER`` when testing over SSL. You also need to
+assign the name ``ubuntu`` to that IP address, since our fabfile uses that hostname to connect, when
+running management commands. You will need to add::
 
-    33.33.33.10 <domain>
+    33.33.33.10 <domain> ubuntu
 
 where ``<domain>`` matches the domain in ``conf/pillar/local.sls``. For example, let's use
 dev.example.com::
 
-    33.33.33.10 dev.example.com
+    33.33.33.10 dev.example.com ubuntu
 
 In your browser you can now view https://dev.example.com and see the VM running the full web stack.
 

--- a/docs/dev/vagrant.rst
+++ b/docs/dev/vagrant.rst
@@ -6,8 +6,9 @@ Starting the VM
 ------------------------
 
 You can test the provisioning/deployment using `Vagrant <http://vagrantup.com/>`_. This requires
-Vagrant 1.7+. The Vagrantfile is configured to install the Salt Master and Minion inside the VM once
-you've run ``vagrant up``. The box will be installed if you don't have it already.::
+Vagrant 1.8.7+ and `VirtualBox <https://www.virtualbox.org/wiki/Testbuilds>`_ version 5 with a
+revision number greater than or equal to 112195. The box will be installed if you don't have it
+already.::
 
     vagrant up
 
@@ -23,7 +24,7 @@ be checked into version control because it can only be used on the developer's l
 finalize the provisioning you simply need to run::
 
     fab vagrant setup_master
-    fab vagrant setup_minion:salt-master,db-master,cache,web,balancer -H 127.0.0.1:2222
+    fab vagrant setup_minion:salt-master,db-master,cache,web,balancer -H 33.33.33.10
     fab vagrant deploy
 
 The above command will setup Vagrant to run the full stack. If you want to test only a subset

--- a/docs/dev/vagrant.rst
+++ b/docs/dev/vagrant.rst
@@ -6,9 +6,8 @@ Starting the VM
 ------------------------
 
 You can test the provisioning/deployment using `Vagrant <http://vagrantup.com/>`_. This requires
-Vagrant 1.8.7+ and `VirtualBox <https://www.virtualbox.org/wiki/Testbuilds>`_ version 5 with a
-revision number greater than or equal to 112195. The box will be installed if you don't have it
-already.::
+Vagrant 1.8.7+ and VirtualBox (``apt-get install virtualbox``). The box will be installed if you
+don't have it already.::
 
     vagrant up
 

--- a/docs/dev/vagrant.rst
+++ b/docs/dev/vagrant.rst
@@ -4,10 +4,12 @@ Vagrant Testing
 Quickstart
 ------------------------
 
-Here is a one-liner to delete any existing vagrant VM, rebuild it and deploy our code to it. It
-takes about 20-30 minutes on my box. See below for further explanations on what these commands do::
+Here is a one-liner to set your ``project_name``, delete any existing vagrant VM, rebuild it and
+deploy our code to it. It takes about 20-30 minutes on my box. See below for further explanations on
+what these commands do::
 
-  vagrant destroy && \
+  sed -i 's/project_name: example/project_name: {{ project_name }}/g' conf/pillar/project.sls && \
+    vagrant destroy && \
     vagrant up && \
     fab vagrant setup_master && \
     fab vagrant setup_minion:salt-master,db-master,cache,web,balancer -H 33.33.33.10 && \
@@ -29,9 +31,10 @@ so here are notes of the Vagrant specifics.
 Provisioning the VM
 ------------------------
 
-Set your environment variables and secrets in ``conf/pillar/local.sls``. It is OK for this to
-be checked into version control because it can only be used on the developer's local machine. To
-finalize the provisioning you simply need to run::
+The only variable that absolutely must be set is ``project_name`` in ``conf/pillar/project.sls``.
+This should be set to ``{{ project_name}}``. Set other environment variables and secrets in
+``conf/pillar/local.sls``. It is OK for this to be checked into version control because it can only
+be used on the developer's local machine. To finalize the provisioning run::
 
     fab vagrant setup_master
     fab vagrant setup_minion:salt-master,db-master,cache,web,balancer -H 33.33.33.10

--- a/fabfile.py
+++ b/fabfile.py
@@ -7,6 +7,7 @@ import yaml
 
 from fabric.api import env, execute, get, hide, local, put, require, run, settings, sudo, task
 from fabric.contrib import files, project
+from fabric.exceptions import NetworkError
 from fabric.utils import abort
 
 DEFAULT_SALT_LOGLEVEL = 'info'
@@ -132,6 +133,12 @@ def setup_master():
     """Provision master with salt-master."""
     require('environment')
     with settings(host_string=env.master):
+        if env.environment == 'local':
+            # First SSH connection to vagrant box often fails. So catch and retry
+            try:
+                sudo('echo is SSH working?')
+            except NetworkError as e:
+                print(e + "but let's try again")
         sudo('apt-get update -qq')
         sudo('apt-get install python-pip git-core python-git python-gnupg haveged -qq -y')
         sudo('mkdir -p /etc/salt/')

--- a/fabfile.py
+++ b/fabfile.py
@@ -138,7 +138,7 @@ def setup_master():
             try:
                 sudo('echo is SSH working?')
             except NetworkError as e:
-                print(e + "but let's try again")
+                print(e.message + ", but let's try again")
         sudo('apt-get update -qq')
         sudo('apt-get install python-pip git-core python-git python-gnupg haveged -qq -y')
         sudo('mkdir -p /etc/salt/')

--- a/fabfile.py
+++ b/fabfile.py
@@ -43,12 +43,12 @@ def production():
 @task
 def vagrant():
     env.environment = 'local'
-    env.user = 'vagrant'
+    env.master = '33.33.33.10'
     # convert vagrant's ssh-config output to a dictionary
     ssh_config_output = local('vagrant ssh-config', capture=True)
     ssh_config = dict(line.split() for line in ssh_config_output.splitlines())
-    env.master = '{HostName}:{Port}'.format(**ssh_config)
     env.key_filename = ssh_config['IdentityFile'].strip('"')
+    env.user = ssh_config['User']
     initialize_env()
 
 
@@ -127,10 +127,34 @@ def install_salt(version, master=False, minion=False, restart=True):
     return False
 
 
+def vbox_version_is_ok():
+    """
+    Return True if installed VirtualBox will work for us.
+    See https://bugs.launchpad.net/cloud-images/+bug/1616794
+
+    Version should be a string like 5.0.31r112195.
+    We need major version 5, and revision must be >= 112195.
+    """
+    GOOD_VBOX_MAJOR_VERSION = '5'
+    GOOD_VBOX_REVISION = 112195
+    vbox_version = local('vboxmanage --version', capture=True)
+    if vbox_version and vbox_version.startswith(GOOD_VBOX_MAJOR_VERSION):
+        if 'r' in vbox_version:
+            revision = int(vbox_version.split('r')[1])
+            if revision >= GOOD_VBOX_REVISION:
+                return True
+    return False
+
+
 @task
 def setup_master():
     """Provision master with salt-master."""
     require('environment')
+    if env.environment == 'local':
+        if not vbox_version_is_ok():
+            abort('Update VirtualBox to version 5.0 or 5.1, revision >= 112195. '
+                  'Instructions: https://www.virtualbox.org/wiki/Testbuilds')
+
     with settings(host_string=env.master):
         sudo('apt-get update -qq')
         sudo('apt-get install python-pip git-core python-git python-gnupg haveged -qq -y')
@@ -233,8 +257,11 @@ def add_role(name):
 @task
 def salt(cmd, target="'*'", loglevel=DEFAULT_SALT_LOGLEVEL):
     """Run arbitrary salt commands."""
+    pillar = ''
+    if env.environment == 'local':
+        pillar = "pillar='{}'".format({'vagrant_user': env.user})
     with settings(warn_only=True, host_string=env.master):
-        result = sudo("salt {0} -l{1} {2} ".format(target, loglevel, cmd))
+        result = sudo('salt {0} -l{1} {2} {3}'.format(target, loglevel, cmd, pillar))
     return result
 
 


### PR DESCRIPTION
NOTE: This should be reviewed after #280 (Xenial upgrade) is merged because I did all my testing with those changes in place.

Issues addressed:
- Require upgrade of vagrant to version >= 1.8.7 because using a private networking address was fixed in that version. (I tested with the latest vagrant, which is 1.9.1)
- Because of the broken networking, we had switched to using 127.0.0.1:2222 in some places, but since it's working, I reverted those all to use 33.33.33.10 again
- NPM install caused OOM errors, so I had to bump the VM memory up to 2G
- Even after bumping up the memory, I was getting strange kernel errors which would cause the VM to be unreachable. If I was logged into the server at the time, all commands would result in an input/output error. Finally found this [issue](https://bugs.launchpad.net/cloud-images/+bug/1616794) which refers to a VirtualBox problem causing VM corruption. Fortunately this has just been fixed in VirtualBox, but it requires you to uninstall the Ubuntu-provided VirtualBox and use the latest stable deploy from Oracle. I tested it, and it works. I added a check during the 'fab vagrant deploy' step to make sure that the vbox version was good before proceeding. (Couldn't figure out a way to do it cleanly in the 'vagrant up' step)
- Use a xenial box image
- The username on the xenial box image has changed from 'vagrant' to 'ubuntu'. Rather than hardcoding it again, I added code to get the proper username from vagrant and then to send that info via the pillar to margarita. See https://github.com/caktus/margarita/pull/148, which needs to be merged for this to work.
