### PR TITLE
Adding a missing slash in a code snippet in `README.rst`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ To start a new project with this template::
     django-admin.py startproject \
       --template=https://github.com/caktus/django-project-template/zipball/master \
       --extension=py,rst,yml \
-      --name=Makefile,gulpfile.js,package.json
+      --name=Makefile,gulpfile.js,package.json \
       <project_name>
 
 {% endif %}


### PR DESCRIPTION
If you copypaste the `django-admin.py startproject \` snippet as is, it will not work, as there is a missing slash. This adds that slash such that it works as advertised.