### PR TITLE
Requires.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,5 @@
 {% if False %}
+.. image:: https://requires.io/github/caktus/django-project-template/requirements.svg?branch=master
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,9 @@
 {% if False %}
+
 .. image:: https://requires.io/github/caktus/django-project-template/requirements.svg?branch=master
 
 Installation
-------------
+============
 
 To start a new project with this template::
 
@@ -13,7 +14,7 @@ To start a new project with this template::
       <project_name>
 
 License
--------
+=======
 
 Copyright (c) 2017, Caktus Consulting Group, LLC
 

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,8 @@
 
 .. image:: https://requires.io/github/caktus/django-project-template/requirements.svg?branch=master
 
+(See `our requires.io documentation <http://caktus.github.io/developer-documentation/services/dep-tracking.html#requires-io>`_).
+
 Installation
 ============
 

--- a/docs/dev/converting-legacy-projects.rst
+++ b/docs/dev/converting-legacy-projects.rst
@@ -1,5 +1,5 @@
 Converting legacy projects to the project template
-=================================
+==================================================
 
 The project template represents our standard setup for new projects, as well as
 our standard suite of build tools for local development. When we
@@ -112,6 +112,7 @@ Once you add a role, you will need to update ``fabfile.py`` by adding a new
 entry to the ``VALID_ROLES`` variable:
 
 ::
+
    VALID_ROLES = (
        #  ...
        'solr',

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "gulp-util": "^3.0.0",
     "immutable": "^3.7.6",
     "isparta": "^4.0.0",
-    "jquery": "^2.1",
+    "jquery": "^3.0.0",
     "jsdom": "^8.3.0",
     "jsdom-global": "^1.7.0",
     "less": "^2.5.3",

--- a/project_name/settings/deploy.py
+++ b/project_name/settings/deploy.py
@@ -1,3 +1,5 @@
+# flake8: noqa
+
 # Settings for live deployed environments: vagrant, staging, production, etc
 import os
 

--- a/project_name/settings/dev.py
+++ b/project_name/settings/dev.py
@@ -1,3 +1,5 @@
+# flake8: noqa
+import os
 import sys
 
 from {{ project_name }}.settings.base import *  # noqa

--- a/project_name/settings/dev.py
+++ b/project_name/settings/dev.py
@@ -7,6 +7,9 @@ DEBUG = True
 INSTALLED_APPS += (
     'debug_toolbar',
 )
+MIDDLEWARE += (
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
+)
 
 INTERNAL_IPS = ('127.0.0.1', )
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,12 +1,16 @@
-psycopg2==2.7.3
-Pillow==2.9.0
-Django==1.8.18
-six==1.9.0
+psycopg2==2.7.4
+Pillow==5.0.0
+# The comment on the next line tells requests.io to warn us if there's a newer
+# version of Django within the given range, but not for versions outside that
+# range. So if 1.11.12 gets released, we get warned. If 2.0.1 gets released,
+# we don't.
+Django==1.11.11  # rq.filter: >=1.11.11,<2.0
+six==1.11.0
 
-BeautifulSoup4==4.4.0
+BeautifulSoup4==4.6.0
 
-django-dotenv==1.3.0
+django-dotenv==1.4.2
 dealer==2.0.5
 
-dj-database-url==0.4.2
-whitenoise==3.3.0
+dj-database-url==0.5.0
+whitenoise==3.3.1

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -1,9 +1,9 @@
 # These are the requirements for a virtualenv that can be used to run 'fabric' to do a deploy,
 # *NOT* the requirements for a server running this Django site.
-PyYAML==3.11
-Fabric==1.10.2
+PyYAML==3.12
+Fabric==1.14.0
 # Required by Fabric
-paramiko==1.15.2
+paramiko==2.4.1
 pycrypto==2.6.1
 ecdsa==0.13
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,25 +1,25 @@
 -r base.txt
-django-debug-toolbar==1.4
+django-debug-toolbar==1.9.1
 # Required by django-debug-toolbar
-sqlparse==0.1.18
+sqlparse==0.2.4
 
-coverage==3.7.1
-flake8==2.4.1
+coverage==4.5.1
+flake8==3.5.0
 # Required by flake8
-pyflakes==0.8.1
-pep8==1.5.7
-mccabe==0.3.1
+pyflakes==1.6.0
+pep8==1.7.1
+mccabe==0.6.1
 
 # For translation
-transifex-client==0.11b3
+transifex-client==0.13.1
 
 requires.io
 
 # For docs
-Sphinx==1.3.6
-sphinx-rtd-theme==0.1.9
-alabaster==0.7.7
-Babel==2.2.0
-docutils==0.12
-Pygments==2.1.3
+Sphinx==1.7.2
+sphinx-rtd-theme==0.2.4
+alabaster==0.7.10
+Babel==2.5.3
+docutils==0.14
+Pygments==2.2.0
 snowballstemmer==1.2.1


### PR DESCRIPTION
* Add directive in requirements to tell requires.io that we're not ready for Django 2.0 yet
* Upgrade most python package requirements
* Add a badge to show whether we're up-to-date