### PR TITLE
Use argon2 password hasher by default

### DIFF
--- a/project_name/settings/base.py
+++ b/project_name/settings/base.py
@@ -182,7 +182,7 @@ STATICFILES_DIRS = (
 # If using Celery, tell it to obey our logging configuration.
 CELERYD_HIJACK_ROOT_LOGGER = False
 
-# https://docs.djangoproject.com/en/1.9/topics/auth/passwords/#password-validation
+# https://docs.djangoproject.com/en/{{ docs_version }}/topics/auth/passwords/#password-validation
 AUTH_PASSWORD_VALIDATORS = [
     {
         'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
@@ -205,3 +205,12 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 SECURE_BROWSER_XSS_FILTER = True
 CSRF_COOKIE_HTTPONLY = True
 X_FRAME_OPTIONS = 'DENY'
+
+# Use the argon2 password hasher (but maintain compatibility with older hashers). See:
+# https://docs.djangoproject.com/en/{{ docs_version }}/topics/auth/passwords/#using-argon2-with-django
+PASSWORD_HASHERS = [
+    'django.contrib.auth.hashers.Argon2PasswordHasher',
+    'django.contrib.auth.hashers.PBKDF2PasswordHasher',
+    'django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher',
+    'django.contrib.auth.hashers.BCryptSHA256PasswordHasher',
+]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,9 +2,9 @@ psycopg2==2.7.4
 Pillow==5.0.0
 # The comment on the next line tells requests.io to warn us if there's a newer
 # version of Django within the given range, but not for versions outside that
-# range. So if 1.11.12 gets released, we get warned. If 2.0.1 gets released,
+# range. So if 1.11.21 gets released, we get warned. If 2.0.1 gets released,
 # we don't.
-Django==1.11.11  # rq.filter: >=1.11.11,<2.0
+Django[argon2]==1.11.20  # rq.filter: >=1.11.20,<2.0
 six==1.11.0
 
 BeautifulSoup4==4.6.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -11,7 +11,7 @@ pep8==1.7.1
 mccabe==0.6.1
 
 # For translation
-transifex-client==0.13.1
+transifex-client==0.13.6
 
 requires.io
 


### PR DESCRIPTION
This PR:

* Switches the default password hasher to argon2, as recommended in the Django docs: https://docs.djangoproject.com/en/1.11/topics/auth/passwords/#using-argon2-with-django
* Upgrades `transifex-client==0.13.6` (the only version wasn't even installable anymore