### PR TITLE
Touch output of gulp compiles to update modtime

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,6 +20,8 @@ var mocha = require('gulp-mocha');
 var istanbul = require('gulp-istanbul');
 var isparta = require('isparta');
 var coverageEnforcer = require('gulp-istanbul-enforcer');
+// Note: this touch only updates the modtime of an existing file, but will never
+// create an empty file (unlike the command-line "touch").
 var touch = require('gulp-touch-fd');
 var spawn = require('child_process').spawn;
 var argv = require('yargs')
@@ -97,7 +99,7 @@ var browserifyTask = function () {
         .pipe(rename('bundle.js'))
         .pipe(gulp.dest(options.dest))
         .pipe(gulpif(options.development, livereload()))
-        .pipe(gulpif(!options.development, touch()))
+        .pipe(touch())
         .pipe(notify(function () {
           console.log('APP bundle built in ' + (Date.now() - start) + 'ms');
         }));
@@ -152,6 +154,7 @@ var cssTask = function () {
           .pipe(less(lessOpts))
           .pipe(rename('bundle.css'))
           .pipe(gulp.dest(options.css.dest))
+          .pipe(touch())
           .pipe(notify(function () {
             console.log('CSS bundle built in ' + (Date.now() - start) + 'ms');
           }));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,7 @@ var mocha = require('gulp-mocha');
 var istanbul = require('gulp-istanbul');
 var isparta = require('isparta');
 var coverageEnforcer = require('gulp-istanbul-enforcer');
-
+var touch = require('gulp-touch-fd');
 var spawn = require('child_process').spawn;
 var argv = require('yargs')
   .default('port', 8000)
@@ -68,6 +68,7 @@ gulp.task('modernizr', function() {
         .pipe(modernizr())
         .pipe(gulpif(!options.development, streamify(uglify())))
         .pipe(gulp.dest(options.modernizr.dest))
+        .pipe(touch())
 })
 
 var browserifyTask = function () {
@@ -96,6 +97,7 @@ var browserifyTask = function () {
         .pipe(rename('bundle.js'))
         .pipe(gulp.dest(options.dest))
         .pipe(gulpif(options.development, livereload()))
+        .pipe(gulpif(!options.development, touch()))
         .pipe(notify(function () {
           console.log('APP bundle built in ' + (Date.now() - start) + 'ms');
         }));
@@ -126,6 +128,7 @@ var browserifyTask = function () {
       .pipe(source('vendors.js'))
       .pipe(gulpif(!options.development, streamify(uglify())))
       .pipe(gulp.dest(options.dest))
+      .pipe(touch())
       .pipe(notify(function () {
         console.log('VENDORS bundle built in ' + (Date.now() - start) + 'ms');
       }));
@@ -161,7 +164,8 @@ var cssTask = function () {
         .pipe(less(lessOpts))
         .pipe(rename('bundle.css'))
         .pipe(cleancss())
-        .pipe(gulp.dest(options.css.dest));
+        .pipe(gulp.dest(options.css.dest))
+        .pipe(touch())
     }
 };
 gulp.task('css', cssTask);

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "gulp-notify": "^3.2.0",
     "gulp-rename": "^1.4.0",
     "gulp-streamify": "1.0.2",
+    "gulp-touch-fd": "github:funkedigital/gulp-touch-fd",
     "gulp-uglify": "^3.0.2",
     "immutable": "^3.8.2",
     "isparta": "^4.1.1",


### PR DESCRIPTION
Gulp is setting the modtime on bundle.css to the modtime of index.less, even if other .less files that it includes are newer. And collectstatic only copies files if the source file's modtime is newer than an existing target file's modtime. So, Gulp might be recompiling the styles, but collectstatic won't copy them because they don't look newer than what's already there.

    To fix this, the gulpfile is modified to set the modtime of the result of each compilation to the current time.